### PR TITLE
Simplify CI and move to Python 3.9-3.10 & Node 20-22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         node: [20, 22]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20, 22]
-        python-version: ['3.9', '3.10']
+        include:
+          - node: 20
+            python: '3.9'
+          - node: 22
+            python: '3.10'
+    name: Test on Node ${{ matrix.node }} + Python ${{ matrix.python }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -20,7 +24,7 @@ jobs:
         run: yarn --frozen-lockfile
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python }}
           cache: pip
       - name: pip> Install dependencies
         run: pip install -r requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,57 +1,29 @@
-name: CI Django and Node
-
+name: CI
 on:
   pull_request:
-
+  push:
+    branches: [master]
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
-
-      - name: Cache node_modules
-        uses: actions/cache@v3.3.2
-        id: cached-node_modules
-        with:
-          path: |
-            node_modules
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-
-      - name: Install all yarn packages
-        if: steps.cached-node_modules.outputs.cache-hit != 'true'
-        run: |
-          yarn --frozen-lockfile
-
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v4
+          cache: yarn
+      - name: yarn> Install node modules
+        run: yarn --frozen-lockfile
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.8'
-
-      - name: Cache pip
-        uses: actions/cache@v3.3.2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}-${{ hashFiles('dev-requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install Dependencies
-        run: |
-          pip install -U pip wheel --progress-bar off
-          pip install -r requirements.txt --progress-bar off
-
-      - name: Run lints
+          cache: pip
+      - name: pip> Install dependencies
+        run: pip install -r requirements.txt
+      - name: Lint app & client
         run: |
           black --check app.py
           flake8 app.py
           yarn prettier:check
-
       - name: Build client
-        run: |
-          yarn run build
+        run: yarn run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
             python: '3.9'
           - node: 22
             python: '3.10'
-    name: Test on Node ${{ matrix.node }} + Python ${{ matrix.python }}
+    name: node:${{ matrix.node }} / python:${{ matrix.python }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master]
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "20"
           cache: yarn
       - name: yarn> Install node modules
         run: yarn --frozen-lockfile
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: "3.10"
           cache: pip
       - name: pip> Install dependencies
         run: pip install -r requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,21 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [20, 22]
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: ${{ matrix.node }}
           cache: yarn
       - name: yarn> Install node modules
         run: yarn --frozen-lockfile
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
           cache: pip
       - name: pip> Install dependencies
         run: pip install -r requirements.txt


### PR DESCRIPTION
Results:

**3.9** has the wheels
**3.10** builds some
**3.11** fails to build (`greenlet`)
→ so SQL deps need bumping (major) along with Flask (minor at minimum) next…

No need to test two-dimensional matrix, just a selection to represent both axis for now.